### PR TITLE
Add gwg-bindgen as wasm-bindgen interop example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A curated list of links to miniquad/macroquad-related code & resources.
 - [With naia](https://github.com/naia-rs/naia-macroquad-example)
 - [With nakama](https://github.com/heroiclabs/fishgame-macroquad)
 - [JS interop](https://github.com/not-fl3/miniquad-js-interop-demo)
+- [wasm-bindgen interop](https://github.com/smokku/gwg-bindgen)
 
 ## Libraries
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A curated list of links to miniquad/macroquad-related code & resources.
 - [With naia](https://github.com/naia-rs/naia-macroquad-example)
 - [With nakama](https://github.com/heroiclabs/fishgame-macroquad)
 - [JS interop](https://github.com/not-fl3/miniquad-js-interop-demo)
-- [wasm-bindgen interop](https://github.com/smokku/gwg-bindgen)
+- [wasm-bindgen interop](https://github.com/smokku/gwg-bindgen) - GWG + wasm-bindgen example
 
 ## Libraries
 


### PR DESCRIPTION
This shows how to interop with wasm-bindgen generated modules.