### PR TITLE
Added TawnyAV to Apps or visualizations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ A curated list of links to miniquad/macroquad-related code & resources.
 - [cacophony](https://github.com/subalterngames/cacophony) - a minimalist and ergonomic MIDI sequencer.
 - [Verlet Physics Playground](https://codeberg.org/polaris64/verlet-physics-playground-macroquad) - a Verlet physics playground demo.
 - [evolution-rs](https://github.com/kostareg/evolution-rs) - simulating the evolution of tiny neural networks.
+- [TawnyAC](https://github.com/LeonStansfield/tawnyAV) - Live audio-visual software built on macroquad designed to display dynamic visualizations based on audio captured from a microphone.
 
 ## Printed Books
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ A curated list of links to miniquad/macroquad-related code & resources.
 - [cacophony](https://github.com/subalterngames/cacophony) - a minimalist and ergonomic MIDI sequencer.
 - [Verlet Physics Playground](https://codeberg.org/polaris64/verlet-physics-playground-macroquad) - a Verlet physics playground demo.
 - [evolution-rs](https://github.com/kostareg/evolution-rs) - simulating the evolution of tiny neural networks.
-- [TawnyAC](https://github.com/LeonStansfield/tawnyAV) - Live audio-visual software built on macroquad designed to display dynamic visualizations based on audio captured from a microphone.
+- [TawnyAV](https://github.com/LeonStansfield/tawnyAV) - Live audio-visual software built on macroquad designed to display dynamic visualizations based on audio captured from a microphone.
 
 ## Printed Books
 


### PR DESCRIPTION
I have been working on a macroquad based tool called TawnyAV.  (https://github.com/LeonStansfield/tawnyAV).
Tawny AV is an audio-visual software built in Rust that is designed to display dynamic visualizations based on live audio captured from a microphone.
I figured it was worth putting in a PR to get it added to this list to make it easier for macroquad users to find if they may find it useful.
Let me know if this is fine, if theres a better way to request this or if you would like any changes to the PR.
Thanks,
Leon.