### PR TITLE
Add "Riichi Mahjong RS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A curated list of links to miniquad/macroquad-related code & resources.
 - [Planets!](https://alakajam.com/21st-alakajam/1594/planets/) - a puzzle game about building stable planet systems.
 - [Dangerous Dave: Rust Ed.](https://github.com/oawad79/dave-rs) - a 2D platformer game inspired by the classic "Dangerous Dave" game.
 - [The Cheese Chase](https://sattva9.itch.io/the-cheese-chase) - a simple arcade game where you play as a rat collecting cheese while avoiding rat repellent spray.
+- [Riichi Mahjong RS](https://github.com/h1g0/riichi_mahjong_rs) - an implementation for Japanese Riichi Mahjong game in Rust.
 
 ### Games: On top of miniquad
 


### PR DESCRIPTION
Adds my [Riichi Mahjong RS](https://github.com/h1g0/riichi_mahjong_rs), a [Japanese Riichi Mahjong](https://en.wikipedia.org/wiki/Japanese_mahjong) game built with Rust and Macroquad. It supports browser and native play, with CPU opponents and online multiplayer.

[Play in your browser](https://riichi-mahjong-rs.vercel.app)

![Riichi Mahjong RS](https://raw.githubusercontent.com/h1g0/riichi_mahjong_rs/refs/heads/main/docs/img/screenshots/en/image1.png)